### PR TITLE
Rename/refactor Perms

### DIFF
--- a/bukkit/src/main/java/haveric/stackableItems/Commands.java
+++ b/bukkit/src/main/java/haveric/stackableItems/Commands.java
@@ -3,6 +3,7 @@ package haveric.stackableItems;
 import haveric.stackableItems.config.Config;
 import haveric.stackableItems.config.FurnaceXPConfig;
 import haveric.stackableItems.util.FurnaceUtil;
+import haveric.stackableItems.util.PermissionsUtil;
 import haveric.stackableItems.util.SIItems;
 import haveric.stackableItems.uuidFetcher.UUIDFetcher;
 
@@ -54,7 +55,7 @@ public class Commands implements CommandExecutor {
         boolean hasAdminPerm = false;
         if (sender instanceof Player) {
             Player player = (Player) sender;
-            hasAdminPerm = Perms.hasAdmin(player);
+            hasAdminPerm = PermissionsUtil.hasAdmin(player);
         }
 
         if (commandLabel.equalsIgnoreCase(cmdMain) || commandLabel.equalsIgnoreCase(cmdMainAlt)) {
@@ -98,7 +99,7 @@ public class Commands implements CommandExecutor {
             } else if (args.length == 1 && (args[0].equalsIgnoreCase(cmdPerms) || args[0].equalsIgnoreCase(cmdPermsAlt))) {
                 if (op || hasAdminPerm) {
                     sender.sendMessage(title + "Permission nodes:");
-                    sender.sendMessage(Perms.getPermAdmin() + " - " + msgColor + "Allows use of admin commands.");
+                    sender.sendMessage(PermissionsUtil.getAdminPermission() + " - " + msgColor + "Allows use of admin commands.");
                 } else {
                     sender.sendMessage(title + ChatColor.RED + "You must be an op or have admin perms to see permission nodes.");
                 }

--- a/bukkit/src/main/java/haveric/stackableItems/StackableItems.java
+++ b/bukkit/src/main/java/haveric/stackableItems/StackableItems.java
@@ -14,6 +14,7 @@ import haveric.stackableItems.listeners.SIPlayerJoinQuitListener;
 import haveric.stackableItems.listeners.SIPlayerListener;
 import haveric.stackableItems.util.FurnaceUtil;
 import haveric.stackableItems.util.InventoryUtil;
+import haveric.stackableItems.util.PermissionsUtil;
 import haveric.stackableItems.util.SIItems;
 import net.milkbowl.vault.permission.Permission;
 
@@ -63,7 +64,7 @@ public class StackableItems extends JavaPlugin {
         if (pm.getPlugin("Vault") != null) {
             RegisteredServiceProvider<Permission> permProvider = getServer().getServicesManager().getRegistration(Permission.class);
             if (permProvider != null) {
-                Perms.init(this, permProvider.getProvider());
+                PermissionsUtil.init(this, permProvider.getProvider());
             }
         }
     }

--- a/bukkit/src/main/java/haveric/stackableItems/util/PermissionsUtil.java
+++ b/bukkit/src/main/java/haveric/stackableItems/util/PermissionsUtil.java
@@ -1,34 +1,35 @@
-package haveric.stackableItems;
+package haveric.stackableItems.util;
 
+import haveric.stackableItems.StackableItems;
 import haveric.stackableItems.config.Config;
 import net.milkbowl.vault.permission.Permission;
 
 import org.bukkit.entity.Player;
 
-public final class Perms {
+public final class PermissionsUtil {
 
-    private static Permission perm = null;
+    private static Permission provider = null;
     private static StackableItems plugin = null;
 
     private static String admin = "stackableitems.admin";
 
-    private Perms() { } // Private constructor for utility class
+    private PermissionsUtil() { } // Private constructor for utility class
 
-    public static void init(StackableItems si, Permission p) {
-        plugin = si;
-        perm = p;
+    public static void init(StackableItems plugin, Permission provider) {
+        PermissionsUtil.plugin = plugin;
+        PermissionsUtil.provider = provider;
     }
 
-    private static boolean permEnabled() {
-        return (perm != null);
+    private static boolean isEnabled() {
+        return (provider != null);
     }
 
     public static boolean groupExists(String group) {
         boolean groupExists = false;
 
-        if (permEnabled()) {
+        if (isEnabled()) {
             try {
-                for (String g : perm.getGroups()) {
+                for (String g : provider.getGroups()) {
                     if (g.equals(group)) {
                         groupExists = true;
                         break;
@@ -51,9 +52,9 @@ public final class Perms {
     public static String[] getPlayerGroups(Player player) {
         String[] groups = null;
 
-        if (permEnabled()) {
+        if (isEnabled()) {
             try {
-                groups = perm.getPlayerGroups(player);
+                groups = provider.getPlayerGroups(player);
             } catch (Exception e) {
                 // No groups
                 if (Config.isDebugging()) {
@@ -68,9 +69,9 @@ public final class Perms {
     public static String[] getGroups() {
         String[] groups = null;
 
-        if (permEnabled()) {
+        if (isEnabled()) {
             try {
-                groups = perm.getGroups();
+                groups = provider.getGroups();
             } catch (Exception e) {
                 // No groups
                 if (Config.isDebugging()) {
@@ -81,7 +82,7 @@ public final class Perms {
         return groups;
     }
 
-    public static String getPermAdmin() {
+    public static String getAdminPermission() {
         return admin;
     }
 }

--- a/bukkit/src/main/java/haveric/stackableItems/util/SIItems.java
+++ b/bukkit/src/main/java/haveric/stackableItems/util/SIItems.java
@@ -1,6 +1,5 @@
 package haveric.stackableItems.util;
 
-import haveric.stackableItems.Perms;
 import haveric.stackableItems.StackableItems;
 import haveric.stackableItems.config.Config;
 import haveric.stackableItems.uuidFetcher.UUIDFetcher;
@@ -319,7 +318,7 @@ public final class SIItems {
                 if (max == ITEM_DEFAULT) {
                     String[] groups = null;
                     try {
-                        groups = Perms.getPlayerGroups(player);
+                        groups = PermissionsUtil.getPlayerGroups(player);
                     } catch (Exception e) {
                         // No Groups
                         if (Config.isDebugging()) {


### PR DESCRIPTION
- Renamed Perms to PermissionsUtil, because "Perms" doesn't really describe much
- Moved PermissionsUtil to utils/
- Made a few other names/methods a bit more descriptive
